### PR TITLE
Fix selectHvacPage: wrap input/href in section block

### DIFF
--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -140,15 +140,17 @@ def linkPage() {
 
 def selectHvacPage() {
     dynamicPage(name: "selectHvacPage", title: "Select HVAC", install: false, uninstall: false) {
-        Map opts = (state.sfpHvacChoices ?: [:])
-        input "chosenHvac", "enum", title: "Thermostat", required: true,
-              options: opts, submitOnChange: true
-        if (settings.chosenHvac) {
-            String id = settings.chosenHvac.toString()
-            paragraph "Selected: ${opts[id] ?: id}"
-            href "chooseHvac", title: "Save Selection",
-                 style: "external",
-                 url: "${appEndpointBase()}/chooseHvac?access_token=${getOrCreateAppToken()}&id=${URLEncoder.encode(id,'UTF-8')}"
+        section("Choose Thermostat") {
+            Map opts = (state.sfpHvacChoices ?: [:])
+            input "chosenHvac", "enum", title: "Thermostat", required: true,
+                  options: opts, submitOnChange: true
+            if (settings.chosenHvac) {
+                String id = settings.chosenHvac.toString()
+                paragraph "Selected: ${opts[id] ?: id}"
+                href "chooseHvac", title: "Save Selection",
+                     style: "external",
+                     url: "${appEndpointBase()}/chooseHvac?access_token=${getOrCreateAppToken()}&id=${URLEncoder.encode(id,'UTF-8')}"
+            }
         }
     }
 }


### PR DESCRIPTION
Hubitat requires all inputs and hrefs to be inside section blocks. The missing section was causing 'Cannot get property input on null object' error.