### PR TITLE
Add in-app version check and HPM package manifest

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,0 +1,36 @@
+{
+  "packageName": "SmartFilterPro Thermostat Bridge",
+  "author": "Eric Hanfman",
+  "version": "1.0.0",
+  "minimumHEVersion": "2.3.0",
+  "dateReleased": "2026-02-16",
+  "releaseNotes": "Initial HPM release - 8-state thermostat tracking with sequence numbering and event buffer for gap detection.",
+  "communityLink": "",
+  "apps": [
+    {
+      "id": "5a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+      "name": "SmartFilterPro Thermostat Bridge (8-State)",
+      "namespace": "smartfilterpro",
+      "location": "https://raw.githubusercontent.com/smartfilterpro/smartfilterpro-hubitat-app/main/SmartFilterProHubitatApp.groovy",
+      "required": true,
+      "oauth": false,
+      "primary": true
+    }
+  ],
+  "drivers": [
+    {
+      "id": "6b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+      "name": "SmartFilterPro Status Sensor",
+      "namespace": "smartfilterpro",
+      "location": "https://raw.githubusercontent.com/smartfilterpro/smartfilterpro-hubitat-app/main/SmartFilterProResetStatus.groovy",
+      "required": false
+    },
+    {
+      "id": "7c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
+      "name": "SmartFilterPro Reset Button",
+      "namespace": "smartfilterpro",
+      "location": "https://raw.githubusercontent.com/smartfilterpro/smartfilterpro-hubitat-app/main/SmartFilterProResetButton.groovy",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
- Add APP_VERSION constant (1.0.0) and VERSION_CHECK_URL
- Add checkForUpdate() that fetches packageManifest.json from GitHub and compares semantic versions to detect newer releases
- Show update notification banner on mainPage when update available
- Display current version in About section on mainPage
- Schedule daily version check (3am) plus 30s after initialize
- Create packageManifest.json for Hubitat Package Manager (HPM) with app and both driver files included

https://claude.ai/code/session_01TWHT1QTH6kaUTe2UXYewwd