### PR TITLE
Fix timestamps to always use UTC instead of hub local timezone

### DIFF
--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -809,7 +809,7 @@ private Map buildCoreEventFromDevice(def dev, String eventType, Integer runtimeS
     // Allow override for health check scenarios
     boolean isReachable = (overrideIsReachable != null) ? overrideIsReachable : true
 
-    String ts = new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", location?.timeZone ?: TimeZone.getTimeZone("UTC"))
+    String ts = new Date().toInstant().toString()
 
     // Use 8-state equipment status
 	String finalEquipStatus = equipmentStatus ?: eventType ?: "Idle"  // Changed from "Fan_off"

--- a/SmartFilterProResetButton.groovy
+++ b/SmartFilterProResetButton.groovy
@@ -26,7 +26,7 @@ def push(buttonNumber = 1) {
     if (result) {
         log.info "✅ Filter reset successful"
         sendEvent(name: "pushed", value: buttonNumber, isStateChange: true)
-        sendEvent(name: "lastReset", value: new Date().format("yyyy-MM-dd HH:mm:ss", location?.timeZone))
+        sendEvent(name: "lastReset", value: new Date().toInstant().toString())
     } else {
         log.warn "⚠️ Filter reset may have failed - check parent app logs"
         sendEvent(name: "pushed", value: buttonNumber, isStateChange: true)

--- a/SmartFilterProResetStatus.groovy
+++ b/SmartFilterProResetStatus.groovy
@@ -59,7 +59,7 @@ def updateStatus(Map status) {
         sendEvent(name: "lastUpdated", value: status.lastUpdated)
     }
 
-    def refreshTime = new Date().format("yyyy-MM-dd HH:mm:ss", location?.timeZone)
+    def refreshTime = new Date().toInstant().toString()
     log.debug "Setting lastRefresh: ${refreshTime}"
     sendEvent(name: "lastRefresh", value: refreshTime)
 


### PR DESCRIPTION
All timestamp generation now uses new Date().toInstant().toString() which produces ISO-8601 UTC format (e.g. 2025-10-18T12:34:56.789Z), replacing the previous timezone-dependent new Date().format() calls that could produce local-time timestamps when the hub's timezone was set to a non-UTC zone.

Files changed:
- SmartFilterProHubitatApp.groovy: Core ingest payload timestamps
- SmartFilterProResetButton.groovy: Reset button display timestamp
- SmartFilterProResetStatus.groovy: Status sensor refresh timestamp

https://claude.ai/code/session_011VEuQiJ9CSamVHhpvNZ94Z