### PR TITLE
Fix re-authentication 404 error on linkPage

### DIFF
--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -131,8 +131,8 @@ def mainPage() {
 def linkPage() {
     dynamicPage(name: "linkPage", title: "Link SmartFilterPro", install: false, uninstall: false) {
         section("Sign In") {
-            input "loginEmail", "email", title: "Email", required: true
-            input "loginPassword", "password", title: "Password", required: true
+            input "loginEmail", "email", title: "Email", required: true, submitOnChange: true
+            input "loginPassword", "password", title: "Password", required: true, submitOnChange: true
             href name: "doLogin", title: "Authenticate", style: "external",
                  description: "Tap to log in (opens new tab)",
                  url: "${appEndpointBase()}/login?access_token=${getOrCreateAppToken()}"
@@ -442,10 +442,12 @@ def cloudLogin() {
             log.info "📋 Multiple HVACs found: ${choices}"
         }
 
-        app.updateSetting("loginPassword", [type:"password", value:""])
+        app.removeSetting("loginPassword")
+        state.lastLoginError = null
         _html("Login complete. Close this tab and return to the app.")
     } catch (e) {
         log.error "Login error: ${e}"
+        state.lastLoginError = e.toString()
         _html("Login failed: ${e}")
     }
 }


### PR DESCRIPTION
The re-link/re-authenticate flow failed with 404 because:

1. The email and password inputs on linkPage lacked submitOnChange, so credentials entered by the user were never persisted before the external "Authenticate" link opened a new tab to call cloudLogin(). The first login worked because credentials were entered on mainPage and saved during the internal navigation to linkPage.

2. Password clearing used app.updateSetting with an empty value, which for Hubitat's password type may store a non-empty encrypted form, bypassing the empty-credential guard and sending garbage to the Bubble API (which returned 404).

Changes:
- Add submitOnChange: true to email/password inputs on linkPage so values are persisted as soon as the user leaves each field
- Use app.removeSetting instead of updateSetting-with-empty to properly clear the password after successful login
- Persist login errors to state.lastLoginError so the existing error display section on linkPage actually shows diagnostic info

https://claude.ai/code/session_01JHEnixkYUAMHZ5gRrg9nDM