### PR TITLE
Fix duplicate events by deferring sequence number reservation

### DIFF
--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -24,7 +24,7 @@ import groovy.transform.Field
 @Field static final String BUBBLE_STATUS_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_therm_status"
 @Field static final String BUBBLE_RESET_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_reset_filter"
 
-@Field static final String  APP_VERSION = "1.0.1"
+@Field static final String  APP_VERSION = "1.0.2"
 @Field static final String  VERSION_CHECK_URL = "https://raw.githubusercontent.com/smartfilterpro/smartfilterpro-hubitat-app/main/packageManifest.json"
 
 @Field static final Integer DEFAULT_HTTP_TIMEOUT = 30
@@ -995,7 +995,9 @@ private Map buildCoreEventFromDevice(def dev, String eventType, Integer runtimeS
         equipment_status: finalEquipStatus,  // Use 8-state value
         is_active: finalIsActive,
         runtime_seconds: runtimeSeconds,
-        sequence_number: reserveSequenceNumber(state.sfpHvacId),
+        // sequence_number is reserved in _postToCoreWithJwt, AFTER the
+        // dedup check (_claimModeChangeSlot) has passed, so duplicate
+        // events that get blocked never consume a sequence number.
         timestamp: ts,
         recorded_at: ts,
         observed_at: ts,
@@ -1030,6 +1032,18 @@ private boolean _postToCoreWithJwt(Object body) {
     }
 
     List batch = (body instanceof List) ? (body as List) : [body]
+
+    // Reserve sequence numbers ONLY for events we're actually posting.
+    // By this point the dedup check (_claimModeChangeSlot) in handleEvent
+    // has already passed, so blocked duplicate events never consume a
+    // sequence number. Reserved here (before buffering) because both the
+    // event buffer and Core dedup key on sequence_number.
+    batch.each { evt ->
+        Map event = evt as Map
+        if (!event.sequence_number) {
+            event.sequence_number = reserveSequenceNumber((event.device_id ?: state.sfpHvacId) as String)
+        }
+    }
 
     // Buffer events on the fresh path only. Outbox drain retries
     // call _doCorePost directly and skip buffering, so this is the

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,10 +1,10 @@
 {
   "packageName": "SmartFilterPro Thermostat Bridge",
   "author": "Eric Hanfman",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minimumHEVersion": "2.3.0",
-  "dateReleased": "2026-04-11",
-  "releaseNotes": "Deduplicate Mode_Change events caused by overlapping thermostat attribute subscriptions firing within milliseconds of each other on a single state transition.",
+  "dateReleased": "2026-06-15",
+  "releaseNotes": "Fix duplicate events by deferring sequence number reservation until after deduplication check passes. Eliminates >24h daily runtime totals caused by duplicate event posting.",
   "communityLink": "",
   "apps": [
     {


### PR DESCRIPTION
Move sequence_number reservation out of buildCoreEventFromDevice() and into _postToCoreWithJwt(), which only runs after the dedup check (_claimModeChangeSlot) in handleEvent has passed. Previously every event reserved a unique sequence number before dedup, so overlapping thermostat attribute subscriptions firing within milliseconds produced duplicate events with consecutive sequence numbers, inflating daily runtime totals beyond 24h.

Bump version to 1.0.2 and update release notes.

https://claude.ai/code/session_0147CyyXdyQywe3FKoWcdXtz