### PR TITLE
Fix reset button label not tracking the HVAC name

### DIFF
--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -24,7 +24,7 @@ import groovy.transform.Field
 @Field static final String BUBBLE_STATUS_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_therm_status"
 @Field static final String BUBBLE_RESET_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_reset_filter"
 
-@Field static final String  APP_VERSION = "1.0.4"
+@Field static final String  APP_VERSION = "1.0.5"
 @Field static final String  VERSION_CHECK_URL = "https://raw.githubusercontent.com/smartfilterpro/smartfilterpro-hubitat-app/main/packageManifest.json"
 
 @Field static final Integer DEFAULT_HTTP_TIMEOUT = 30
@@ -542,6 +542,12 @@ def initialize() {
     } else {
         deleteResetDevice()
     }
+
+    // Reconcile child device labels to the current HVAC name. Devices
+    // may have been created while state.sfpHvacName still held a login
+    // placeholder, or the reset button may have been added after the
+    // name was learned — this keeps both labels in sync on every save.
+    updateChildDeviceLabels()
 
     unschedule()
     runEvery30Minutes("heartbeat")
@@ -1342,8 +1348,11 @@ def pollBubbleStatus() {
         if (body.deviceName && body.deviceName != state.sfpHvacName) {
             log.info "📝 HVAC name updated: '${state.sfpHvacName}' → '${body.deviceName}'"
             state.sfpHvacName = body.deviceName
-            updateChildDeviceLabels()
         }
+        // Reconcile child device labels every poll. setLabel is guarded
+        // to a no-op when already correct, so this self-heals any label
+        // (e.g. the reset button) that drifted from the current name.
+        updateChildDeviceLabels()
 
         if (enableDebugLogging) {
             log.debug "✅ Bubble status: filterHealth=${body.filterHealth}%, minutesActive=${body.minutesActive}"

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,10 +1,10 @@
 {
   "packageName": "SmartFilterPro Thermostat Bridge",
   "author": "Eric Hanfman",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "minimumHEVersion": "2.3.0",
   "dateReleased": "2026-06-15",
-  "releaseNotes": "Fix token refresh on 401: also refresh the core JWT when a 401 arrives without throwing (soft 401), detect 401s by status code and body text, and refresh the Bubble access_token via the stored refresh_token so an expired token self-heals instead of going silent. Plus: optional update push notifications and duplicate-event fix.",
+  "releaseNotes": "Fix reset button label not tracking the HVAC name: reconcile both child device labels on every save and status poll so the reset button stays in sync with the status device. Plus: 401/token-refresh fixes, optional update push notifications, and duplicate-event fix.",
   "communityLink": "",
   "apps": [
     {


### PR DESCRIPTION
updateChildDeviceLabels() was only called from the pollBubbleStatus block gated on the name changing, so it fired once when the name flipped from the login placeholder to the real name. The reset button, labeled at creation from a stale state.sfpHvacName, was never reconciled afterward (unlike the status device, which happened to exist when that one call fired). Neither driver sets its own label.

Reconcile both labels on every initialize() after device creation and on every status poll. setLabel is already guarded to a no-op when the label is correct, so this self-heals drifted labels within one poll cycle.

Bump version to 1.0.5 and update release notes.

https://claude.ai/code/session_0147CyyXdyQywe3FKoWcdXtz