### PR TITLE
Bump version to 1.0.6 to validate update notifications

### DIFF
--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -24,7 +24,7 @@ import groovy.transform.Field
 @Field static final String BUBBLE_STATUS_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_therm_status"
 @Field static final String BUBBLE_RESET_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_reset_filter"
 
-@Field static final String  APP_VERSION = "1.0.5"
+@Field static final String  APP_VERSION = "1.0.6"
 @Field static final String  VERSION_CHECK_URL = "https://raw.githubusercontent.com/smartfilterpro/smartfilterpro-hubitat-app/main/packageManifest.json"
 
 @Field static final Integer DEFAULT_HTTP_TIMEOUT = 30

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,10 +1,10 @@
 {
   "packageName": "SmartFilterPro Thermostat Bridge",
   "author": "Eric Hanfman",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "minimumHEVersion": "2.3.0",
   "dateReleased": "2026-06-15",
-  "releaseNotes": "Fix reset button label not tracking the HVAC name: reconcile both child device labels on every save and status poll so the reset button stays in sync with the status device. Plus: 401/token-refresh fixes, optional update push notifications, and duplicate-event fix.",
+  "releaseNotes": "Maintenance release validating the in-app update notification path alongside backend authentication reliability improvements. No functional app changes since 1.0.5.",
   "communityLink": "",
   "apps": [
     {


### PR DESCRIPTION
No functional app changes since 1.0.5; bumps APP_VERSION and the package manifest so installed instances detect an available update and exercise the push-notification path. Pairs with backend authentication updates.

https://claude.ai/code/session_0147CyyXdyQywe3FKoWcdXtz