### PR TITLE
Fix intermittent blank status & false reset success; add test-environment toggle (v1.0.7)

### DIFF
--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -18,13 +18,15 @@ import groovy.transform.Field
 /* ============================== CONSTANTS ============================== */
 
 @Field static final String CORE_INGEST_URL = "https://core.smartfilterpro.com/ingest/v1/events:batch"
-@Field static final String BUBBLE_LOGIN_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_password"
-@Field static final String BUBBLE_REFRESH_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_refresh_token"
-@Field static final String BUBBLE_CORE_JWT_URL = "https://smartfilterpro.com/api/1.1/wf/issue_core_token_hub"
-@Field static final String BUBBLE_STATUS_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_therm_status"
-@Field static final String BUBBLE_RESET_URL = "https://smartfilterpro.com/api/1.1/wf/hubitat_reset_filter"
 
-@Field static final String  APP_VERSION = "1.0.6"
+// Bubble has separate live and development ("version-test") databases.
+// The "Use Test Environment" option routes all Bubble calls to the
+// version-test workflows. Defaults to live so a production install never
+// talks to the dev database.
+@Field static final String BUBBLE_BASE_LIVE = "https://smartfilterpro.com/api/1.1/wf"
+@Field static final String BUBBLE_BASE_TEST = "https://smartfilterpro.com/version-test/api/1.1/wf"
+
+@Field static final String  APP_VERSION = "1.0.7"
 @Field static final String  VERSION_CHECK_URL = "https://raw.githubusercontent.com/smartfilterpro/smartfilterpro-hubitat-app/main/packageManifest.json"
 
 @Field static final Integer DEFAULT_HTTP_TIMEOUT = 30
@@ -89,6 +91,10 @@ def mainPage() {
         }
 
         section("Options") {
+            input "useTestEnvironment", "bool",
+                 title: "Use Test Environment (version-test)",
+                 description: "Routes all SmartFilterPro cloud calls to the Bubble development database. Leave OFF for normal use.",
+                 defaultValue: false, submitOnChange: true
             input "enableDebugLogging", "bool", title: "Enable Debug Logging", defaultValue: true
             input "httpTimeout", "number", title: "HTTP Timeout (seconds)",
                  defaultValue: DEFAULT_HTTP_TIMEOUT, range: "5..120"
@@ -414,7 +420,7 @@ def cloudLogin() {
 
         Map loginResp
         httpPost([
-            uri: BUBBLE_LOGIN_URL,
+            uri: bubbleUrl("hubitat_password"),
             contentType: "application/json",
             body: [ email: email, password: pwd ],
             timeout: (settings.httpTimeout ?: DEFAULT_HTTP_TIMEOUT)
@@ -475,6 +481,16 @@ private def _html(String msg) {
 
 private Map _bubbleBody(Map resp) {
     return (resp?.response ?: resp) as Map
+}
+
+/**
+ * Build a Bubble workflow URL for the current environment. When the
+ * "Use Test Environment" option is on, routes to the version-test
+ * (development) database; otherwise to live.
+ */
+private String bubbleUrl(String workflow) {
+    String base = settings?.useTestEnvironment ? BUBBLE_BASE_TEST : BUBBLE_BASE_LIVE
+    return "${base}/${workflow}"
 }
 
 /* ============================== LIFECYCLE ============================== */
@@ -1227,7 +1243,7 @@ private boolean _issueCoreTokenOrLog(boolean isRetry = false) {
 
         Map respMap
         httpPost([
-            uri: BUBBLE_CORE_JWT_URL,
+            uri: bubbleUrl("issue_core_token_hub"),
             contentType: "application/json",
             requestContentType: "application/json",
             headers: [ Authorization: "Bearer ${at}" ],
@@ -1290,7 +1306,7 @@ private boolean _refreshBubbleAccessToken() {
 
         Map respMap
         httpPost([
-            uri: BUBBLE_REFRESH_URL,
+            uri: bubbleUrl("hubitat_refresh_token"),
             contentType: "application/json",
             requestContentType: "application/json",
             body: [ user_id: state.sfpUserId, refresh_token: rt ],
@@ -1322,7 +1338,7 @@ private boolean _refreshBubbleAccessToken() {
 
 /* ============================== BUBBLE STATUS POLLING ============================== */
 
-def pollBubbleStatus() {
+def pollBubbleStatus(boolean isRetry = false) {
     if (!state.sfpAccessToken || !state.sfpHvacId) {
         if (enableDebugLogging) log.debug "⏭️ Skipping status poll (not linked)"
         return
@@ -1333,7 +1349,7 @@ def pollBubbleStatus() {
 
         Map respMap
         httpPost([
-            uri: BUBBLE_STATUS_URL,
+            uri: bubbleUrl("hubitat_therm_status"),
             contentType: "application/json",
             requestContentType: "application/json",
             headers: [ Authorization: "Bearer ${state.sfpAccessToken}" ],
@@ -1342,6 +1358,32 @@ def pollBubbleStatus() {
         ]) { resp -> respMap = resp.data }
 
         Map body = _bubbleBody(respMap)
+
+        // Bubble returns HTTP 200 even on failure, wrapping the real error
+        // inside the body, e.g.
+        //   { status:"success", response:{ Body:"...invalid_token...", status:401 } }
+        // and an unresolved request can also come back as an empty
+        // response:{}. Detect both so we never overwrite a good tile with
+        // nulls — the cause of the intermittent "blank status".
+        Integer innerStatus = (body?.status instanceof Number) ? (body.status as Integer) : null
+        String innerBody = (body?.Body ?: "").toString().toLowerCase()
+        boolean hasPayload = (body?.filterHealth != null) || (body?.deviceName != null)
+        boolean looksLikeError = (innerStatus != null && innerStatus >= 400) ||
+                                 innerBody.contains("invalid_token") ||
+                                 innerBody.contains("\"error\"")
+
+        if (looksLikeError || !hasPayload) {
+            log.warn "⚠️ Status poll returned no valid payload (innerStatus=${innerStatus}); keeping last known status. Detail: ${body?.Body ?: body}"
+            // A wrapped 401 means an expired access_token OR an hvac_id not
+            // tied to it. Refresh once and retry; if the id is the problem
+            // this still fails and we simply keep the previous good status.
+            if (!isRetry && innerStatus == 401 && _refreshBubbleAccessToken()) {
+                pollBubbleStatus(true)
+            }
+            return
+        }
+
+        // Valid payload from here on.
         state.sfpLastStatus = body
 
         // Update HVAC name if it changed in Bubble
@@ -2033,7 +2075,7 @@ def resetNow() {
 
         Map respMap
         httpPost([
-            uri: BUBBLE_RESET_URL,
+            uri: bubbleUrl("hubitat_reset_filter"),
             contentType: "application/json",
             requestContentType: "application/json",
             headers: [ Authorization: "Bearer ${state.sfpAccessToken}" ],

--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -1368,16 +1368,20 @@ def pollBubbleStatus(boolean isRetry = false) {
         Integer innerStatus = (body?.status instanceof Number) ? (body.status as Integer) : null
         String innerBody = (body?.Body ?: "").toString().toLowerCase()
         boolean hasPayload = (body?.filterHealth != null) || (body?.deviceName != null)
-        boolean looksLikeError = (innerStatus != null && innerStatus >= 400) ||
-                                 innerBody.contains("invalid_token") ||
+        boolean authError = (innerStatus == 401) ||
+                            innerBody.contains("invalid_token") ||
+                            innerBody.contains("expired") ||
+                            innerBody.contains("unauthorized")
+        boolean looksLikeError = authError ||
+                                 (innerStatus != null && innerStatus >= 400) ||
                                  innerBody.contains("\"error\"")
 
         if (looksLikeError || !hasPayload) {
             log.warn "⚠️ Status poll returned no valid payload (innerStatus=${innerStatus}); keeping last known status. Detail: ${body?.Body ?: body}"
-            // A wrapped 401 means an expired access_token OR an hvac_id not
-            // tied to it. Refresh once and retry; if the id is the problem
-            // this still fails and we simply keep the previous good status.
-            if (!isRetry && innerStatus == 401 && _refreshBubbleAccessToken()) {
+            // A wrapped auth error means an expired access_token OR an
+            // hvac_id not tied to it. Refresh once and retry; if the id is
+            // the problem this still fails and we keep the previous status.
+            if (!isRetry && authError && _refreshBubbleAccessToken()) {
                 pollBubbleStatus(true)
             }
             return

--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -493,6 +493,25 @@ private String bubbleUrl(String workflow) {
     return "${base}/${workflow}"
 }
 
+/**
+ * Inspect an unwrapped Bubble body for a wrapped error. Bubble returns
+ * HTTP 200 even on failure, nesting the real status in the body, e.g.
+ *   { Body:"...invalid_token...", status:401 }.
+ * Returns [ error: boolean, authError: boolean, status: Integer ].
+ */
+private Map _bubbleResult(Map body) {
+    Integer innerStatus = (body?.status instanceof Number) ? (body.status as Integer) : null
+    String innerBody = (body?.Body ?: "").toString().toLowerCase()
+    boolean authError = (innerStatus == 401) ||
+                        innerBody.contains("invalid_token") ||
+                        innerBody.contains("expired") ||
+                        innerBody.contains("unauthorized")
+    boolean isError = authError ||
+                      (innerStatus != null && innerStatus >= 400) ||
+                      innerBody.contains("\"error\"")
+    return [ error: isError, authError: authError, status: innerStatus ]
+}
+
 /* ============================== LIFECYCLE ============================== */
 
 def installed() {
@@ -1365,23 +1384,15 @@ def pollBubbleStatus(boolean isRetry = false) {
         // and an unresolved request can also come back as an empty
         // response:{}. Detect both so we never overwrite a good tile with
         // nulls — the cause of the intermittent "blank status".
-        Integer innerStatus = (body?.status instanceof Number) ? (body.status as Integer) : null
-        String innerBody = (body?.Body ?: "").toString().toLowerCase()
+        Map result = _bubbleResult(body)
         boolean hasPayload = (body?.filterHealth != null) || (body?.deviceName != null)
-        boolean authError = (innerStatus == 401) ||
-                            innerBody.contains("invalid_token") ||
-                            innerBody.contains("expired") ||
-                            innerBody.contains("unauthorized")
-        boolean looksLikeError = authError ||
-                                 (innerStatus != null && innerStatus >= 400) ||
-                                 innerBody.contains("\"error\"")
 
-        if (looksLikeError || !hasPayload) {
-            log.warn "⚠️ Status poll returned no valid payload (innerStatus=${innerStatus}); keeping last known status. Detail: ${body?.Body ?: body}"
+        if (result.error || !hasPayload) {
+            log.warn "⚠️ Status poll returned no valid payload (innerStatus=${result.status}); keeping last known status. Detail: ${body?.Body ?: body}"
             // A wrapped auth error means an expired access_token OR an
             // hvac_id not tied to it. Refresh once and retry; if the id is
             // the problem this still fails and we keep the previous status.
-            if (!isRetry && authError && _refreshBubbleAccessToken()) {
+            if (!isRetry && result.authError && _refreshBubbleAccessToken()) {
                 pollBubbleStatus(true)
             }
             return
@@ -2068,7 +2079,7 @@ private boolean _isHttpClientError(String errMsg) {
 
 /* ============================== FILTER RESET ============================== */
 
-def resetNow() {
+def resetNow(boolean isRetry = false) {
     if (!state.sfpAccessToken || !state.sfpHvacId) {
         log.warn "❌ Cannot reset filter - not linked to SmartFilterPro"
         return false
@@ -2088,6 +2099,19 @@ def resetNow() {
         ]) { resp -> respMap = resp.data }
 
         Map body = _bubbleBody(respMap)
+
+        // Bubble returns HTTP 200 even on failure, wrapping the real error
+        // in the body — don't report success on a wrapped auth/error.
+        Map result = _bubbleResult(body)
+        if (result.error) {
+            log.warn "⚠️ Filter reset failed (innerStatus=${result.status}): ${body?.Body ?: body}"
+            // On a wrapped auth error, refresh the token and retry once.
+            if (!isRetry && result.authError && _refreshBubbleAccessToken()) {
+                return resetNow(true)
+            }
+            return false
+        }
+
         log.info "✅ Filter reset successful: ${body}"
 
         // Refresh status after reset

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,10 +1,10 @@
 {
   "packageName": "SmartFilterPro Thermostat Bridge",
   "author": "Eric Hanfman",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "minimumHEVersion": "2.3.0",
   "dateReleased": "2026-06-15",
-  "releaseNotes": "Maintenance release validating the in-app update notification path alongside backend authentication reliability improvements. No functional app changes since 1.0.5.",
+  "releaseNotes": "Fix intermittent blank status: detect Bubble responses that return HTTP 200 while wrapping an error (e.g. nested 401) or an empty payload, so an error no longer overwrites the last good status tile; refresh the token and retry once on a wrapped 401. Add an optional 'Use Test Environment' toggle to route cloud calls to the version-test database (defaults to live).",
   "communityLink": "",
   "apps": [
     {

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -4,7 +4,7 @@
   "version": "1.0.7",
   "minimumHEVersion": "2.3.0",
   "dateReleased": "2026-06-15",
-  "releaseNotes": "Fix intermittent blank status: detect Bubble responses that return HTTP 200 while wrapping an error (e.g. nested 401) or an empty payload, so an error no longer overwrites the last good status tile; refresh the token and retry once on a wrapped 401. Add an optional 'Use Test Environment' toggle to route cloud calls to the version-test database (defaults to live).",
+  "releaseNotes": "Fix intermittent blank status: detect Bubble responses that return HTTP 200 while wrapping an error (e.g. nested 401) or an empty payload, so an error no longer overwrites the last good status tile or reports a false reset success; refresh the token and retry once on a wrapped auth error (status poll and filter reset). Add an optional 'Use Test Environment' toggle to route cloud calls to the version-test database (defaults to live).",
   "communityLink": "",
   "apps": [
     {


### PR DESCRIPTION
Bumps to **v1.0.7**.

### Fix intermittent blank status / false reset success
Bubble returns **HTTP 200 even on failure**, wrapping the real error in the body, e.g. `{ status:"success", response:{ Body:"...invalid_token...", status:401 } }`, and an unresolved request can return an empty `response:{}`. The app previously treated every 200 as a valid payload:
- `pollBubbleStatus` overwrote the status tile with nulls → intermittent blank status.
- `resetNow` logged "Filter reset successful" on a wrapped error.

Now a shared `_bubbleResult()` helper detects the wrapped error (nested `status >= 400`, or `invalid_token`/`expired`/`unauthorized`/`"error"` in the body). On error the code **keeps the last good status** (and reports reset failure), and on a wrapped **auth** error it refreshes the token via `_refreshBubbleAccessToken()` and **retries once** (bounded by an `isRetry` guard).

### Add "Use Test Environment" toggle
Bubble has separate live and `version-test` databases. URLs are now built via `bubbleUrl(workflow)` from one of two bases, switched by a new **"Use Test Environment"** option. **Defaults to live**, so a production install never talks to the dev database.

### Notes
- A wrapped 401 can also mean a wrong/untied `hvac_id` (not just an expired token); in that case the single retry safely fails and the last good status is preserved.
- Refresh+retry depends on the `hubitat_refresh_token` workflow returning a usable `access_token` for `{ user_id, refresh_token }`.

https://claude.ai/code/session_0147CyyXdyQywe3FKoWcdXtz

---
_Generated by [Claude Code](https://claude.ai/code/session_0147CyyXdyQywe3FKoWcdXtz)_