### PR TITLE
Refresh access_token on soft-401 when issuing core_token

### DIFF
--- a/SmartFilterProHubitatApp.groovy
+++ b/SmartFilterProHubitatApp.groovy
@@ -1280,10 +1280,21 @@ private boolean _issueCoreTokenOrLog(boolean isRetry = false) {
             state.sfpCoreTokenExp = exp
             log.info "✅ Core token refreshed (exp: ${exp})"
             return true
-        } else {
-            log.error "❌ Core token response missing token: ${body}"
-            return false
         }
+
+        // Soft 401: Bubble rejected our access_token in the response body
+        // (status:401 / invalid_token) rather than throwing, so the catch
+        // block below never runs. Mirror its self-heal path here — refresh
+        // the access_token once and re-issue. Without this an expired
+        // access_token never recovers and events are dropped until a manual
+        // re-link, even though the refresh_token is sitting right there.
+        Map authCheck = _bubbleResult(body)
+        if (authCheck.authError && !isRetry && _refreshBubbleAccessToken()) {
+            return _issueCoreTokenOrLog(true)
+        }
+
+        log.error "❌ Core token response missing token: ${body}"
+        return false
     } catch (Exception e) {
         String msg = e.toString()
         String lower = msg.toLowerCase()


### PR DESCRIPTION
## Problem

The core JWT refresh logic was firing but failing to self-heal when the underlying **Bubble access_token** is expired.

Observed in production logs:

```
🔄 Requesting new core_token from Bubble...
❌ Core token response missing token: [Body:{ "error": "invalid_token",
   "message": "Access token expired or invalid" }, status:401]
❌ Core permanent error (401_refresh_failed) — dropping 1 event(s)
```

`issue_core_token_hub` returns a **wrapped 401** (`status:401` / `invalid_token` inside the response body) when the access_token is expired. That arrives through the `httpPost` success closure rather than being thrown, so `_issueCoreTokenOrLog` fell into the missing-token `else` branch and returned `false` — never reaching the `catch` block that refreshes the access_token. `_doCorePost` then reported `401_refresh_failed` and dropped the batch, leaving the app stuck until a manual re-link despite a valid `refresh_token` being available.

This is the same soft-401 pattern already handled in `_doCorePost`, but the equivalent fix was never applied to `_issueCoreTokenOrLog`.

## Fix

After the missing-token check, inspect the parsed body with the existing `_bubbleResult()` helper. If it's a wrapped auth error, run the same refresh-and-retry the `catch` block already does for thrown 401s — refresh the access_token once (guarded by `isRetry` to bound recursion) and re-issue the core_token.

## Effect

The expired-access_token case now recovers automatically instead of dropping events:

```
🔄 Requesting new core_token from Bubble...
🔄 Refreshing Bubble access_token via refresh_token...
✅ Bubble access_token refreshed
🔄 Requesting new core_token from Bubble...
✅ Core token refreshed
```

Still requires a valid stored `refresh_token`; if that's also expired it logs the existing re-link message as before.

https://claude.ai/code/session_01YM9YN2DVARpfktdSFnbcMn

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM9YN2DVARpfktdSFnbcMn)_