### PR TITLE
Fix BigDecimal.round crash in status sensor updateStatus

### DIFF
--- a/SmartFilterProResetStatus.groovy
+++ b/SmartFilterProResetStatus.groovy
@@ -43,7 +43,11 @@ def updateStatus(Map status) {
     }
 
     if (status.minutesActive != null) {
-        def hours = (status.minutesActive / 60).round(2)
+        // BigDecimal has no round(int) — only round(MathContext) — so a
+        // fractional minutesActive (e.g. 2714.55) made .round(2) throw and
+        // abort the whole updateStatus, dropping every event. setScale with
+        // an explicit RoundingMode is the correct BigDecimal API.
+        def hours = (status.minutesActive as BigDecimal).divide(60g, 2, java.math.RoundingMode.HALF_UP)
         log.debug "Setting minutesActive: ${status.minutesActive}, hoursActive: ${hours}"
         sendEvent(name: "minutesActive", value: status.minutesActive, unit: "min")
         sendEvent(name: "hoursActive", value: hours, unit: "hr")


### PR DESCRIPTION
A fractional minutesActive (e.g. 2714.55) made (minutesActive / 60) a BigDecimal, and BigDecimal has no round(int) — only round(MathContext). .round(2) threw MissingMethodException, aborting updateStatus entirely so no filterHealth/minutesActive/etc. events were sent.

Compute hours with BigDecimal.divide(60, 2, HALF_UP), which sets the scale and rounding in one call and also avoids the non-terminating decimal ArithmeticException that plain divide() would raise.